### PR TITLE
Fix gopath in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="kierranm@gmail.com" \
 RUN useradd -u 10001 deadmanswatch
 
 # Copy the code from the host and compile it
-WORKDIR $GOPATH/src/github.com/kierranm/deadmanswatch
-COPY ./vendor $GOPATH/src/github.com/kierranm/deadmanswatch/vendor
-COPY ./main.go $GOPATH/src/github.com/kierranm/deadmanswatch/main.go
-COPY ./cmd $GOPATH/src/github.com/kierranm/deadmanswatch/cmd
+WORKDIR $GOPATH/src/github.com/KierranM/deadmanswatch
+COPY ./vendor $GOPATH/src/github.com/KierranM/deadmanswatch/vendor
+COPY ./main.go $GOPATH/src/github.com/KierranM/deadmanswatch/main.go
+COPY ./cmd $GOPATH/src/github.com/KierranM/deadmanswatch/cmd
 RUN go test ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /deadmanswatch .
 


### PR DESCRIPTION
Docker build is currently erroring with:
```
[91mmain.go:4:2: cannot find package "github.com/KierranM/deadmanswatch/cmd" in any of:
	/go/src/github.com/kierranm/deadmanswatch/vendor/github.com/KierranM/deadmanswatch/cmd (vendor tree)
	/usr/local/go/src/github.com/KierranM/deadmanswatch/cmd (from $GOROOT)
	/go/src/github.com/KierranM/deadmanswatch/cmd (from $GOPATH)
```