### PR TITLE
Install cacerts in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.10 AS builder
 LABEL maintainer="kierranm@gmail.com" \
       description="Forwards prometheus DeadMansSwitch alerts to CloudWatch" \
-      version="0.0.1"
+      version="0.0.2"
 
 RUN useradd -u 10001 deadmanswatch
 
@@ -13,9 +13,14 @@ COPY ./cmd $GOPATH/src/github.com/KierranM/deadmanswatch/cmd
 RUN go test ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /deadmanswatch .
 
+FROM alpine:latest AS cacerts
+RUN apk add --update ca-certificates
+
 FROM scratch
 COPY --from=builder /deadmanswatch ./
 COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=cacerts /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 USER deadmanswatch
 WORKDIR /
 ENTRYPOINT ["./deadmanswatch"]

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "0.0.1"
+const Version = "0.0.2"
 
 func init() {
 	rootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
The scratch image has no cacerts, this uses an alpine image layer to get some up to date certs and copies them to the final image