### PR TITLE
Support for aws IRSA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.10 AS builder
 LABEL maintainer="kierranm@gmail.com" \
       description="Forwards prometheus DeadMansSwitch alerts to CloudWatch" \
-      version="0.0.2"
+      version="0.0.3"
 
 RUN useradd -u 10001 deadmanswatch
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.15.82"
+  version = "1.36.12"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/deploy/helm/deadmanswatch/templates/_helpers.tpl
+++ b/deploy/helm/deadmanswatch/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "deadmanswatch.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create serviceAccountName for deployment.
+*/}}
+{{- define "deadmanswatch.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "deadmanswatch.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/deadmanswatch/templates/deployment.yaml
+++ b/deploy/helm/deadmanswatch/templates/deployment.yaml
@@ -88,3 +88,6 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ template "deadmanswatch.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 3000

--- a/deploy/helm/deadmanswatch/templates/serviceaccount.yaml
+++ b/deploy/helm/deadmanswatch/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "deadmanswatch.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "deadmanswatch.name" . }}
+    helm.sh/chart: {{ include "deadmanswatch.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+  {{- if .Values.serviceAccount.annotations }}
+    {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/deadmanswatch/values.yaml
+++ b/deploy/helm/deadmanswatch/values.yaml
@@ -62,3 +62,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # annotations:
+  # Will add the provided map to the annotations for the created serviceAccount
+  # e.g.
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/prom-cloudwatch-exporter-oidc


### PR DESCRIPTION
Hello!
This PR adds support for Service-Accounts, in my case used for [IRSA](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/)
- Added service-account in helm chart
- Updated go aws sdk, minimum required version would be [Go - 1.23.13 ](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html)

I build the docker image locally with the new go sdk version and pushed it to a private repository for testing in EKS, authentication via service-account for cloudwatch worked. I added the fsGroup option to the chart to grant permission on the mounted file from aws: /var/run/secrets/eks.amazonaws.com/serviceaccount/token