### PR TITLE
Adjusting "--metric-dimensions" sintax

### DIFF
--- a/deploy/helm/deadmanswatch/Chart.yaml
+++ b/deploy/helm/deadmanswatch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart for deploying DeadMansWatch
 name: deadmanswatch
-version: 0.0.2
+version: 0.0.3
 home: https://github.com/kierranm/deadmanswatch
 engine: gotpl
 maintainers:

--- a/deploy/helm/deadmanswatch/templates/_helpers.tpl
+++ b/deploy/helm/deadmanswatch/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create serviceAccountName for deployment.
 {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create metric-dimensions string.
+*/}}
+{{- define "deadmanswatch.metric-dimensions" -}}
+{{- $list := list -}}
+{{- range $k, $v := ( .Values.deadmanswatch.metricDimensions ) -}}
+{{- $list = append $list (printf "%s=%s" $k $v) -}}
+{{- end -}}
+{{ join "," $list }}
+{{- end -}}

--- a/deploy/helm/deadmanswatch/templates/deployment.yaml
+++ b/deploy/helm/deadmanswatch/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - --alert-source-label={{.Values.deadmanswatch.alertSourceLabel}}
             {{- end }}
             {{- if .Values.deadmanswatch.metricDimensions }}
-            - --metric-dimensions="{{ range $k, $v := .Values.deadmanswatch.metricDimensions }}{{$k}}={{$v}},{{ end }}"
+            - --metric-dimensions={{ include "deadmanswatch.metric-dimensions" . | quote }}
             {{- end }}
             {{- range $key, $value := .Values.deadmanswatch.extraArgs }}
             {{- if $value }}


### PR DESCRIPTION
This PR adjust the "--metrics-dimensions" string sintax, before this PR the strings has a additional comma:

> args:
....
>   - --metric-dimensions="dimension1=dimension1,dimension2=dimension2,"
> ...

This PR add a logic to create the correct string:

> args:
>   ...
>   - --metric-dimensions="dimension1=dimension1,dimension2=dimension2"
> ...

Regards